### PR TITLE
Fix svgPath issue for paths with spacing

### DIFF
--- a/src/macro.js
+++ b/src/macro.js
@@ -33,7 +33,7 @@ function svgrMacro({
 
     if (isFileExists) {
       // Case 1: single file
-      const jsCode = execSync(`svgr ${svgPath} ${cliArguments}`).toString();
+      const jsCode = execSync(`svgr "${svgPath}" ${cliArguments}`).toString();
       const ast = parse(jsCode, { sourceType: 'module', plugins: ['jsx'] });
       const arrowFunctionExpression = ast.program.body[1].declarations[0].init;
 
@@ -42,7 +42,7 @@ function svgrMacro({
       // Case 2: glob pattern
       const objectProperties = glob.sync(svgPath).map(f => {
         // TODO: merge multiple files and run svgr at same time.
-        const jsCode = execSync(`svgr ${f} ${cliArguments}`).toString();
+        const jsCode = execSync(`svgr "${f}" ${cliArguments}`).toString();
         const ast = parse(jsCode, { sourceType: 'module', plugins: ['jsx'] });
         const componentName = ast.program.body[1].declarations[0].id.name;
         const arrowFunctionExpression =


### PR DESCRIPTION
Currently when a svgPath has a space (for example, `C://owo/John Doe`). The command is executed as `svgr C://owo/John Doe ...`, resulting in the file not being found since it believes the location is `C://owo/John`. Hence, having double quotes around the svgPath would preserve the spaces